### PR TITLE
feat: children type definition updated

### DIFF
--- a/src/components/Stack/Stack.spec.tsx
+++ b/src/components/Stack/Stack.spec.tsx
@@ -1,11 +1,11 @@
-import { mount } from 'cypress/react';
-import { Box } from '~/index';
-import { Stack } from './Stack';
+import { mount } from "cypress/react";
+import { Box } from "~/index";
+import { Stack } from "./Stack";
 
 const Item = () => <Box width={24} height={24} />;
 
-describe('Stack', () => {
-  it('should render successfully', () => {
+describe("Stack", () => {
+  it("should render successfully", () => {
     mount(
       <Stack data-test-id="stack" gap={24}>
         <Item />
@@ -14,16 +14,23 @@ describe('Stack', () => {
       </Stack>
     );
 
-    cy.get('[data-test-id="stack"]').should('exist');
-    cy.get('[data-test-id="stack"]').children().should('have.length', 3);
+    cy.get('[data-test-id="stack"]').should("exist");
+    cy.get('[data-test-id="stack"]').children().should("have.length", 3);
   });
 
-  it('should render divider', () => {
+  it("should render divider", () => {
     mount(
       <Stack
         data-test-id="stack"
         gap={24}
-        divider={<Box width={24} height={4} style={{ background: '#BC00FE' }} data-test-id="divider" />}
+        divider={
+          <Box
+            width={24}
+            height={4}
+            style={{ background: "#BC00FE" }}
+            data-test-id="divider"
+          />
+        }
       >
         <Item />
         <Item />
@@ -31,11 +38,11 @@ describe('Stack', () => {
       </Stack>
     );
 
-    cy.get('[data-test-id="stack"]').children().should('have.length', 5);
-    cy.get('[data-test-id="divider"]').should('have.length', 2);
+    cy.get('[data-test-id="stack"]').children().should("have.length", 5);
+    cy.get('[data-test-id="divider"]').should("have.length", 2);
   });
 
-  it('should render column', () => {
+  it("should render column", () => {
     mount(
       <Stack data-test-id="stack" column gap={24}>
         <Item />
@@ -44,13 +51,13 @@ describe('Stack', () => {
       </Stack>
     );
     cy.get('[data-test-id="stack"]').should(
-      'have.attr',
-      'style',
-      'box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: column nowrap; flex: 0 1 auto; gap: 24px;'
+      "have.attr",
+      "style",
+      "box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: column nowrap; flex: 0 1 auto; gap: 24px;"
     );
   });
 
-  it('should render fluid', () => {
+  it("should render fluid", () => {
     mount(
       <Box width={200} height={200}>
         <Stack data-test-id="stack" fluid>
@@ -62,13 +69,13 @@ describe('Stack', () => {
     );
 
     cy.get('[data-test-id="stack"]').should(
-      'have.attr',
-      'style',
-      'box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: row nowrap; flex: 0 1 auto; justify-content: space-between; width: 100%;'
+      "have.attr",
+      "style",
+      "box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: row nowrap; flex: 0 1 auto; justify-content: space-between; width: 100%;"
     );
   });
 
-  it('should render fluid and column', () => {
+  it("should render fluid and column", () => {
     mount(
       <Box width={200} height={200}>
         <Stack data-test-id="stack" fluid column>
@@ -79,13 +86,13 @@ describe('Stack', () => {
       </Box>
     );
     cy.get('[data-test-id="stack"]').should(
-      'have.attr',
-      'style',
-      'box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: column nowrap; flex: 0 1 auto; justify-content: space-between; height: 100%;'
+      "have.attr",
+      "style",
+      "box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: column nowrap; flex: 0 1 auto; justify-content: space-between; height: 100%;"
     );
   });
 
-  it('should render row with wrap', () => {
+  it("should render row with wrap", () => {
     mount(
       <Box width={200} height={200}>
         <Stack data-test-id="stack" wrap gap={24}>
@@ -97,9 +104,28 @@ describe('Stack', () => {
     );
 
     cy.get('[data-test-id="stack"]').should(
-      'have.attr',
-      'style',
-      'box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: row wrap; flex: 0 1 auto; gap: 24px;'
+      "have.attr",
+      "style",
+      "box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: row wrap; flex: 0 1 auto; gap: 24px;"
+    );
+  });
+
+  it("should render row with undefined element", () => {
+    mount(
+      <Box width={200} height={200}>
+        <Stack data-test-id="stack" wrap gap={24}>
+          <Item />
+          <Item />
+          {undefined}
+          <Item />
+        </Stack>
+      </Box>
+    );
+
+    cy.get('[data-test-id="stack"]').should(
+      "have.attr",
+      "style",
+      "box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: row wrap; flex: 0 1 auto; gap: 24px;"
     );
   });
 });

--- a/src/components/Stack/Stack.stories.tsx
+++ b/src/components/Stack/Stack.stories.tsx
@@ -115,3 +115,19 @@ export const RowDivider = () => (
     </Stack>
   </Box>
 );
+
+export const WithUndefinedElement = () => (
+  <Box>
+    <Stack
+      gap={3 * SPACE_UNIT}
+      style={{
+        background: "#EAEAFB",
+      }}
+    >
+      <Item />
+      <Item />
+      {undefined}
+      <Item />
+    </Stack>
+  </Box>
+);

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -1,10 +1,10 @@
-import { Children as ReactChildren, ComponentProps, Fragment } from 'react';
-import { forwardRef } from 'react';
+import { Children as ReactChildren, ComponentProps, Fragment } from "react";
+import { forwardRef } from "react";
 
-import { Box } from '~/components/Box/Box';
-import { Children } from '~/utils/typing/children';
+import { Box } from "~/components/Box/Box";
+import { Children } from "~/utils/typing/children";
 
-export type StackProps = Omit<ComponentProps<typeof Box>, 'size'> & {
+export type StackProps = Omit<ComponentProps<typeof Box>, "size"> & {
   /**
    * The children to render inside the stack. Stack will not accept only 1 child, it must have at least 2. If you need to place only 1 child please prefer using Box.
    * @default []
@@ -72,9 +72,9 @@ export const Stack = forwardRef<HTMLElement, StackProps>((props, ref) => {
   const commonProps = {
     ...boxProps,
     ref: ref,
-    height: fluid && boxProps.column ? '100%' : props.height,
-    width: fluid && !boxProps.column ? '100%' : props.width,
-    'data-test-id': props['data-test-id'],
+    height: fluid && boxProps.column ? "100%" : props.height,
+    width: fluid && !boxProps.column ? "100%" : props.width,
+    "data-test-id": props["data-test-id"],
   };
 
   if (!divider) {
@@ -83,7 +83,7 @@ export const Stack = forwardRef<HTMLElement, StackProps>((props, ref) => {
         {...commonProps}
         style={{
           gap: gap,
-          justifyContent: fluid ? 'space-between' : undefined,
+          justifyContent: fluid ? "space-between" : undefined,
           ...boxProps.style,
           ...props.style,
         }}
@@ -97,7 +97,7 @@ export const Stack = forwardRef<HTMLElement, StackProps>((props, ref) => {
         {...commonProps}
         style={{
           gap: gap ? gap * 0.5 : undefined,
-          justifyContent: fluid ? 'space-between' : undefined,
+          justifyContent: fluid ? "space-between" : undefined,
           ...boxProps.style,
           ...props.style,
         }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,5 @@ export { Box } from "./components/Box/Box";
 export { Space } from "./components/Space/Space";
 export { Stack } from "./components/Stack/Stack";
 export { Grid } from "./components/Grid/Grid";
+
+export type { Children } from "./utils/typing/children";

--- a/src/utils/typing/children.ts
+++ b/src/utils/typing/children.ts
@@ -1,1 +1,6 @@
-export type Children = React.ReactElement<unknown> | React.ReactElement<unknown>[] | boolean | null | undefined;
+export type Children =
+  | React.ReactElement<unknown>
+  | Array<Children>
+  | boolean
+  | null
+  | undefined;


### PR DESCRIPTION
### Description:

Changed `Children` type to better match the `Stack` component API

### Related User Story:

-

### Tasks:

- [X] Change the `Children` type definition
- [X] Added Stack story
- [X] Added test

### Test:

1. run test

### Preview:

<details>
  <summary>Storybook:</summary>
<img width="1049" alt="Schermata 2023-04-20 alle 10 30 59" src="https://user-images.githubusercontent.com/125461397/233308059-9d22ca12-1519-436f-9ff1-05b0e28b5230.png">
  
</details>
