### PR TITLE
🐛 fitering children so that dividers won appears around undefined ele…

### DIFF
--- a/src/components/Box/Box.spec.tsx
+++ b/src/components/Box/Box.spec.tsx
@@ -1,7 +1,7 @@
 import { mount } from 'cypress/react';
 import { Box } from './Box';
 
-describe('View', () => {
+describe('Box', () => {
   it('should render successfully', () => {
     mount(
       <Box data-test-id="view" vAlignContent="center" hAlignContent="right" grow shrink wrap>

--- a/src/components/Grid/Grid.spec.tsx
+++ b/src/components/Grid/Grid.spec.tsx
@@ -1,154 +1,125 @@
-import { mount } from "cypress/react";
-import { Box } from "~/index";
-import { Grid } from "./Grid";
+import { mount } from 'cypress/react';
+import { Box } from '~/index';
+import { Grid } from './Grid';
 
 const SPACE_UNIT = 8;
-
-it("Grid Container should have correct css props", () => {
-  mount(
-    <Grid.Container
-      rows={3}
-      cols={2}
-      colsGap={SPACE_UNIT * 4}
-      rowsGap={SPACE_UNIT}
-      data-test-id="grid-container"
-      style={{
-        background: "red",
-      }}
-    >
-      <Grid.Item data-test-id="grid-item-1">
-        <Box width={100} height={100} />
-      </Grid.Item>
-    </Grid.Container>
-  );
-  cy.get('[data-test-id="grid-container"]')
-    .should("exist")
-    .should(
-      "have.attr",
-      "style",
-      `display: grid; grid-template-columns: repeat(2, 1fr); grid-template-rows: repeat(3, 1fr); gap: ${SPACE_UNIT}px ${
-        SPACE_UNIT * 4
-      }px; background: red;`
-    );
-});
-
-it("Grid Container should have correct children", () => {
-  mount(
-    <Grid.Container rows={3} cols={2} data-test-id="grid-container">
-      <Grid.Item data-test-id="grid-item-1">
-        <Box width={100} height={100} />
-      </Grid.Item>
-      <Grid.Item data-test-id="grid-item-2">
-        <Box width={100} height={100} />
-      </Grid.Item>
-      <Grid.Item data-test-id="grid-item-3">
-        <Box width={100} height={100} />
-      </Grid.Item>
-    </Grid.Container>
-  );
-  cy.get('[data-test-id="grid-container"]').children().should("have.length", 3);
-
-  cy.get('[data-test-id="grid-container"]')
-    .should("exist")
-    .find('[data-test-id="grid-item-1"]')
-    .should("exist");
-  cy.get('[data-test-id="grid-container"]')
-    .should("exist")
-    .find('[data-test-id="grid-item-2"]')
-    .should("exist");
-  cy.get('[data-test-id="grid-container"]')
-    .should("exist")
-    .find('[data-test-id="grid-item-3"]')
-    .should("exist");
-  cy.get('[data-test-id="grid-container"]')
-    .should("exist")
-    .find('[data-test-id="grid-item-4"]')
-    .should("not.exist");
-});
-
-it("Grid Items should have correct parent", () => {
-  mount(
-    <Grid.Container rows={3} cols={2} data-test-id="grid-container">
-      <Grid.Item data-test-id="grid-item-1">
-        <Box width={100} height={100} />
-      </Grid.Item>
-      <Grid.Item data-test-id="grid-item-2">
-        <Box width={100} height={100} />
-      </Grid.Item>
-      <Grid.Item data-test-id="grid-item-3">
-        <Box width={100} height={100} />
-      </Grid.Item>
-    </Grid.Container>
-  );
-  cy.get('[data-test-id="grid-item-1"]')
-    .should("exist")
-    .parent('[data-test-id="grid-container"]');
-  cy.get('[data-test-id="grid-item-2"]')
-    .should("exist")
-    .parent('[data-test-id="grid-container"]');
-  cy.get('[data-test-id="grid-item-3"]')
-    .should("exist")
-    .parent('[data-test-id="grid-container"]');
-});
-
-it("Grid Items should have correct css", () => {
-  mount(
-    <Grid.Container rows={3} cols={2} data-test-id="grid-container">
-      <Grid.Item
-        colStart={1}
-        colEnd={3}
-        rowStart={1}
-        rowEnd={3}
-        data-test-id="grid-item-1"
+describe('Grid', () => {
+  it('Grid Container should have correct css props', () => {
+    mount(
+      <Grid.Container
+        rows={3}
+        cols={2}
+        colsGap={SPACE_UNIT * 4}
+        rowsGap={SPACE_UNIT}
+        data-test-id="grid-container"
         style={{
-          background: "yellow",
+          background: 'red',
         }}
       >
-        <Box width={100} height={100} />
-      </Grid.Item>
-      <Grid.Item
-        colStart={2}
-        colEnd={2}
-        rowStart={2}
-        rowEnd={4}
-        data-test-id="grid-item-2"
-        style={{
-          background: "green",
-        }}
-      >
-        <Box width={100} height={100} />
-      </Grid.Item>
-      <Grid.Item
-        colStart={1}
-        rowStart={4}
-        data-test-id="grid-item-3"
-        style={{
-          background: "red",
-        }}
-      >
-        <Box width={100} height={100} />
-      </Grid.Item>
-    </Grid.Container>
-  );
-  cy.get('[data-test-id="grid-item-1"]')
-    .should("exist")
-    .should(
-      "have.attr",
-      "style",
-      `grid-area: 1 / 1 / 3 / 3; background: yellow;`
+        <Grid.Item data-test-id="grid-item-1">
+          <Box width={100} height={100} />
+        </Grid.Item>
+      </Grid.Container>
     );
-  cy.get('[data-test-id="grid-item-2"]')
-    .should("exist")
-    .should(
-      "have.attr",
-      "style",
-      `grid-area: 2 / 2 / 4 / 2; background: green;`
+    cy.get('[data-test-id="grid-container"]')
+      .should('exist')
+      .should(
+        'have.attr',
+        'style',
+        `display: grid; grid-template-columns: repeat(2, 1fr); grid-template-rows: repeat(3, 1fr); gap: ${SPACE_UNIT}px ${
+          SPACE_UNIT * 4
+        }px; background: red;`
+      );
+  });
+
+  it('Grid Container should have correct children', () => {
+    mount(
+      <Grid.Container rows={3} cols={2} data-test-id="grid-container">
+        <Grid.Item data-test-id="grid-item-1">
+          <Box width={100} height={100} />
+        </Grid.Item>
+        <Grid.Item data-test-id="grid-item-2">
+          <Box width={100} height={100} />
+        </Grid.Item>
+        <Grid.Item data-test-id="grid-item-3">
+          <Box width={100} height={100} />
+        </Grid.Item>
+      </Grid.Container>
     );
-  cy.get('[data-test-id="grid-item-3"]')
-    .should("exist")
-    .should(
-      "have.attr",
-      "style",
-      `grid-column-start: 1; grid-row-start: 4; background: red;`
+    cy.get('[data-test-id="grid-container"]').children().should('have.length', 3);
+
+    cy.get('[data-test-id="grid-container"]').should('exist').find('[data-test-id="grid-item-1"]').should('exist');
+    cy.get('[data-test-id="grid-container"]').should('exist').find('[data-test-id="grid-item-2"]').should('exist');
+    cy.get('[data-test-id="grid-container"]').should('exist').find('[data-test-id="grid-item-3"]').should('exist');
+    cy.get('[data-test-id="grid-container"]').should('exist').find('[data-test-id="grid-item-4"]').should('not.exist');
+  });
+
+  it('Grid Items should have correct parent', () => {
+    mount(
+      <Grid.Container rows={3} cols={2} data-test-id="grid-container">
+        <Grid.Item data-test-id="grid-item-1">
+          <Box width={100} height={100} />
+        </Grid.Item>
+        <Grid.Item data-test-id="grid-item-2">
+          <Box width={100} height={100} />
+        </Grid.Item>
+        <Grid.Item data-test-id="grid-item-3">
+          <Box width={100} height={100} />
+        </Grid.Item>
+      </Grid.Container>
     );
+    cy.get('[data-test-id="grid-item-1"]').should('exist').parent('[data-test-id="grid-container"]');
+    cy.get('[data-test-id="grid-item-2"]').should('exist').parent('[data-test-id="grid-container"]');
+    cy.get('[data-test-id="grid-item-3"]').should('exist').parent('[data-test-id="grid-container"]');
+  });
+
+  it('Grid Items should have correct css', () => {
+    mount(
+      <Grid.Container rows={3} cols={2} data-test-id="grid-container">
+        <Grid.Item
+          colStart={1}
+          colEnd={3}
+          rowStart={1}
+          rowEnd={3}
+          data-test-id="grid-item-1"
+          style={{
+            background: 'yellow',
+          }}
+        >
+          <Box width={100} height={100} />
+        </Grid.Item>
+        <Grid.Item
+          colStart={2}
+          colEnd={2}
+          rowStart={2}
+          rowEnd={4}
+          data-test-id="grid-item-2"
+          style={{
+            background: 'green',
+          }}
+        >
+          <Box width={100} height={100} />
+        </Grid.Item>
+        <Grid.Item
+          colStart={1}
+          rowStart={4}
+          data-test-id="grid-item-3"
+          style={{
+            background: 'red',
+          }}
+        >
+          <Box width={100} height={100} />
+        </Grid.Item>
+      </Grid.Container>
+    );
+    cy.get('[data-test-id="grid-item-1"]')
+      .should('exist')
+      .should('have.attr', 'style', `grid-area: 1 / 1 / 3 / 3; background: yellow;`);
+    cy.get('[data-test-id="grid-item-2"]')
+      .should('exist')
+      .should('have.attr', 'style', `grid-area: 2 / 2 / 4 / 2; background: green;`);
+    cy.get('[data-test-id="grid-item-3"]')
+      .should('exist')
+      .should('have.attr', 'style', `grid-column-start: 1; grid-row-start: 4; background: red;`);
+  });
 });

--- a/src/components/Space/Space.spec.tsx
+++ b/src/components/Space/Space.spec.tsx
@@ -3,43 +3,45 @@ import { Space } from './Space';
 
 const TEST_VALUE = 24;
 
-it('Should have defined height in a column', () => {
-  mount(
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-      }}
-    >
-      <Space size={TEST_VALUE} data-test-id="col" />
-    </div>
-  );
-  cy.get('[data-test-id="col"]').should('have.css', 'height', TEST_VALUE + 'px');
-});
+describe('Space', () => {
+  it('Should have defined height in a column', () => {
+    mount(
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Space size={TEST_VALUE} data-test-id="col" />
+      </div>
+    );
+    cy.get('[data-test-id="col"]').should('have.css', 'height', TEST_VALUE + 'px');
+  });
 
-it('Should have defined width and basis in a row', () => {
-  mount(
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'row',
-      }}
-    >
-      <Space size={TEST_VALUE} data-test-id="row" />
-    </div>
-  );
-  cy.get('[data-test-id="row"]').should('have.css', 'width', TEST_VALUE + 'px');
-});
+  it('Should have defined width and basis in a row', () => {
+    mount(
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+        }}
+      >
+        <Space size={TEST_VALUE} data-test-id="row" />
+      </div>
+    );
+    cy.get('[data-test-id="row"]').should('have.css', 'width', TEST_VALUE + 'px');
+  });
 
-it('Should have flex-grow and flex-shrink if fluid', () => {
-  mount(
-    <div
-      style={{
-        display: 'flex',
-      }}
-    >
-      <Space fluid data-test-id="fluid" />
-    </div>
-  );
-  cy.get('[data-test-id="fluid"]').should('have.css', 'flex-grow', '1');
+  it('Should have flex-grow and flex-shrink if fluid', () => {
+    mount(
+      <div
+        style={{
+          display: 'flex',
+        }}
+      >
+        <Space fluid data-test-id="fluid" />
+      </div>
+    );
+    cy.get('[data-test-id="fluid"]').should('have.css', 'flex-grow', '1');
+  });
 });

--- a/src/components/Stack/Stack.spec.tsx
+++ b/src/components/Stack/Stack.spec.tsx
@@ -1,11 +1,11 @@
-import { mount } from "cypress/react";
-import { Box } from "~/index";
-import { Stack } from "./Stack";
+import { mount } from 'cypress/react';
+import { Box, Children } from '~/index';
+import { Stack } from './Stack';
 
 const Item = () => <Box width={24} height={24} />;
 
-describe("Stack", () => {
-  it("should render successfully", () => {
+describe('Stack', () => {
+  it('should render successfully', () => {
     mount(
       <Stack data-test-id="stack" gap={24}>
         <Item />
@@ -14,23 +14,16 @@ describe("Stack", () => {
       </Stack>
     );
 
-    cy.get('[data-test-id="stack"]').should("exist");
-    cy.get('[data-test-id="stack"]').children().should("have.length", 3);
+    cy.get('[data-test-id="stack"]').should('exist');
+    cy.get('[data-test-id="stack"]').children().should('have.length', 3);
   });
 
-  it("should render divider", () => {
+  it('should render divider', () => {
     mount(
       <Stack
         data-test-id="stack"
         gap={24}
-        divider={
-          <Box
-            width={24}
-            height={4}
-            style={{ background: "#BC00FE" }}
-            data-test-id="divider"
-          />
-        }
+        divider={<Box width={24} height={4} style={{ background: '#BC00FE' }} data-test-id="divider" />}
       >
         <Item />
         <Item />
@@ -38,11 +31,11 @@ describe("Stack", () => {
       </Stack>
     );
 
-    cy.get('[data-test-id="stack"]').children().should("have.length", 5);
-    cy.get('[data-test-id="divider"]').should("have.length", 2);
+    cy.get('[data-test-id="stack"]').children().should('have.length', 5);
+    cy.get('[data-test-id="divider"]').should('have.length', 2);
   });
 
-  it("should render column", () => {
+  it('should render column', () => {
     mount(
       <Stack data-test-id="stack" column gap={24}>
         <Item />
@@ -51,13 +44,13 @@ describe("Stack", () => {
       </Stack>
     );
     cy.get('[data-test-id="stack"]').should(
-      "have.attr",
-      "style",
-      "box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: column nowrap; flex: 0 1 auto; gap: 24px;"
+      'have.attr',
+      'style',
+      'box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: column nowrap; flex: 0 1 auto; gap: 24px;'
     );
   });
 
-  it("should render fluid", () => {
+  it('should render fluid', () => {
     mount(
       <Box width={200} height={200}>
         <Stack data-test-id="stack" fluid>
@@ -69,13 +62,13 @@ describe("Stack", () => {
     );
 
     cy.get('[data-test-id="stack"]').should(
-      "have.attr",
-      "style",
-      "box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: row nowrap; flex: 0 1 auto; justify-content: space-between; width: 100%;"
+      'have.attr',
+      'style',
+      'box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: row nowrap; flex: 0 1 auto; justify-content: space-between; width: 100%;'
     );
   });
 
-  it("should render fluid and column", () => {
+  it('should render fluid and column', () => {
     mount(
       <Box width={200} height={200}>
         <Stack data-test-id="stack" fluid column>
@@ -86,13 +79,13 @@ describe("Stack", () => {
       </Box>
     );
     cy.get('[data-test-id="stack"]').should(
-      "have.attr",
-      "style",
-      "box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: column nowrap; flex: 0 1 auto; justify-content: space-between; height: 100%;"
+      'have.attr',
+      'style',
+      'box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: column nowrap; flex: 0 1 auto; justify-content: space-between; height: 100%;'
     );
   });
 
-  it("should render row with wrap", () => {
+  it('should render row with wrap', () => {
     mount(
       <Box width={200} height={200}>
         <Stack data-test-id="stack" wrap gap={24}>
@@ -104,13 +97,13 @@ describe("Stack", () => {
     );
 
     cy.get('[data-test-id="stack"]').should(
-      "have.attr",
-      "style",
-      "box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: row wrap; flex: 0 1 auto; gap: 24px;"
+      'have.attr',
+      'style',
+      'box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: row wrap; flex: 0 1 auto; gap: 24px;'
     );
   });
 
-  it("should render row with undefined element", () => {
+  it('should render row with undefined element', () => {
     mount(
       <Box width={200} height={200}>
         <Stack data-test-id="stack" wrap gap={24}>
@@ -123,9 +116,29 @@ describe("Stack", () => {
     );
 
     cy.get('[data-test-id="stack"]').should(
-      "have.attr",
-      "style",
-      "box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: row wrap; flex: 0 1 auto; gap: 24px;"
+      'have.attr',
+      'style',
+      'box-sizing: border-box; min-width: 0px; min-height: 0px; display: flex; flex-flow: row wrap; flex: 0 1 auto; gap: 24px;'
     );
+  });
+
+  it('should render dividers = defined children - 1', () => {
+    const children: Children[] = [<Item />, <Item />, undefined, <Item />];
+    mount(
+      <Box width={200} height={200}>
+        <Stack
+          data-test-id="stack"
+          wrap
+          gap={24}
+          divider={<Box width={4} height={24} style={{ background: '#BC00FE' }} />}
+        >
+          {...children}
+        </Stack>
+      </Box>
+    );
+
+    cy.get('[data-test-id="stack"]')
+      .children()
+      .should('have.length', children.filter(child => !!child).length * 2 - 1);
   });
 });

--- a/src/components/Stack/Stack.stories.tsx
+++ b/src/components/Stack/Stack.stories.tsx
@@ -1,24 +1,22 @@
-import { Meta } from "@storybook/react/types-6-0";
-import { Box } from "../Box/Box";
-import { Stack } from "./Stack";
+import { Meta } from '@storybook/react/types-6-0';
+import { Box } from '../Box/Box';
+import { Stack } from './Stack';
 
 export default {
-  title: "Foundations/Stack",
+  title: 'Foundations/Stack',
   component: Stack,
 } as Meta;
 
 const SPACE_UNIT = 8;
 
-const Item = () => (
-  <Box width={24} height={24} style={{ background: "#00E3D8" }} />
-);
+const Item = () => <Box width={24} height={24} style={{ background: '#00E3D8' }} />;
 
 export const RowDefinedGap = () => (
   <Box>
     <Stack
       gap={3 * SPACE_UNIT}
       style={{
-        background: "#EAEAFB",
+        background: '#EAEAFB',
       }}
     >
       <Item />
@@ -35,7 +33,7 @@ export const ColumnDefinedGap = () => (
       column
       gap={3 * SPACE_UNIT}
       style={{
-        background: "#EAEAFB",
+        background: '#EAEAFB',
       }}
     >
       <Item />
@@ -49,8 +47,8 @@ export const ColumnDefinedGap = () => (
 export const RowFluid = () => (
   <div
     style={{
-      width: "400px",
-      background: "#EAEAFB",
+      width: '400px',
+      background: '#EAEAFB',
     }}
   >
     <Stack fluid grow>
@@ -66,8 +64,8 @@ export const ColumnFluid = () => (
   <Box>
     <div
       style={{
-        height: "400px",
-        background: "#EAEAFB",
+        height: '400px',
+        background: '#EAEAFB',
       }}
     >
       <Stack column fluid grow>
@@ -86,9 +84,9 @@ export const ColumnDivider = () => (
       column
       gap={3 * SPACE_UNIT}
       style={{
-        background: "#EAEAFB",
+        background: '#EAEAFB',
       }}
-      divider={<Box width={24} height={4} style={{ background: "#BC00FE" }} />}
+      divider={<Box width={24} height={4} style={{ background: '#BC00FE' }} />}
     >
       <Item />
       <Item />
@@ -103,10 +101,10 @@ export const RowDivider = () => (
     <Stack
       gap={3 * SPACE_UNIT}
       style={{
-        background: "#EAEAFB",
+        background: '#EAEAFB',
       }}
       shrink
-      divider={<Box width={4} height={24} style={{ background: "#BC00FE" }} />}
+      divider={<Box width={4} height={24} style={{ background: '#BC00FE' }} />}
     >
       <Item />
       <Item />
@@ -121,8 +119,25 @@ export const WithUndefinedElement = () => (
     <Stack
       gap={3 * SPACE_UNIT}
       style={{
-        background: "#EAEAFB",
+        background: '#EAEAFB',
       }}
+    >
+      <Item />
+      <Item />
+      {undefined}
+      <Item />
+    </Stack>
+  </Box>
+);
+
+export const WithUndefinedElementAndDivider = () => (
+  <Box>
+    <Stack
+      gap={3 * SPACE_UNIT}
+      style={{
+        background: '#EAEAFB',
+      }}
+      divider={<Box width={4} height={24} style={{ background: '#BC00FE' }} />}
     >
       <Item />
       <Item />

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -1,10 +1,10 @@
-import { Children as ReactChildren, ComponentProps, Fragment } from "react";
-import { forwardRef } from "react";
+import { Children as ReactChildren, ComponentProps, Fragment, useEffect, useState } from 'react';
+import { forwardRef } from 'react';
 
-import { Box } from "~/components/Box/Box";
-import { Children } from "~/utils/typing/children";
+import { Box } from '~/components/Box/Box';
+import { Children } from '~/utils/typing/children';
 
-export type StackProps = Omit<ComponentProps<typeof Box>, "size"> & {
+export type StackProps = Omit<ComponentProps<typeof Box>, 'size'> & {
   /**
    * The children to render inside the stack. Stack will not accept only 1 child, it must have at least 2. If you need to place only 1 child please prefer using Box.
    * @default []
@@ -68,13 +68,18 @@ export type StackProps = Omit<ComponentProps<typeof Box>, "size"> & {
 
 export const Stack = forwardRef<HTMLElement, StackProps>((props, ref) => {
   const { children, fluid, gap, divider, ...boxProps } = props;
+  const [content, setChildren] = useState<Children[]>(children.filter(child => !!child));
+
+  useEffect(() => {
+    setChildren(children.filter(child => !!child));
+  }, [children]);
 
   const commonProps = {
     ...boxProps,
     ref: ref,
-    height: fluid && boxProps.column ? "100%" : props.height,
-    width: fluid && !boxProps.column ? "100%" : props.width,
-    "data-test-id": props["data-test-id"],
+    height: fluid && boxProps.column ? '100%' : props.height,
+    width: fluid && !boxProps.column ? '100%' : props.width,
+    'data-test-id': props['data-test-id'],
   };
 
   if (!divider) {
@@ -83,12 +88,12 @@ export const Stack = forwardRef<HTMLElement, StackProps>((props, ref) => {
         {...commonProps}
         style={{
           gap: gap,
-          justifyContent: fluid ? "space-between" : undefined,
+          justifyContent: fluid ? 'space-between' : undefined,
           ...boxProps.style,
           ...props.style,
         }}
       >
-        {children}
+        {content}
       </Box>
     );
   } else {
@@ -97,15 +102,15 @@ export const Stack = forwardRef<HTMLElement, StackProps>((props, ref) => {
         {...commonProps}
         style={{
           gap: gap ? gap * 0.5 : undefined,
-          justifyContent: fluid ? "space-between" : undefined,
+          justifyContent: fluid ? 'space-between' : undefined,
           ...boxProps.style,
           ...props.style,
         }}
       >
-        {ReactChildren.map(children, (child, index) => (
+        {content.map((child, index) => (
           <Fragment key={index}>
             {child}
-            {index < ReactChildren.count(children) - 1 && divider}
+            {index < content.length - 1 && divider}
           </Fragment>
         ))}
       </Box>


### PR DESCRIPTION
### Description:

FIxed a bug that was causing a sequence of 2 dividers if a child was `undefined` 

### Related User Story:

https://app.clickup.com/t/36635997/FL-179

### Tasks:

- [x] Filtering children 
- [x] Added storybook case 
- [x] Added test case 

### Test:

1. See new storybook case 
